### PR TITLE
Decrease RECEIVER_BUFFER_SIZE to fix the OutOfMemory exception:

### DIFF
--- a/sctp/src/main/java/tr/havelsan/ueransim/sctp/SctpClient.java
+++ b/sctp/src/main/java/tr/havelsan/ueransim/sctp/SctpClient.java
@@ -36,7 +36,7 @@ import java.net.InetSocketAddress;
 import java.nio.ByteBuffer;
 
 public class SctpClient implements ISctpClient {
-    private static final int RECEIVER_BUFFER_SIZE = 1073741824;
+    private static final int RECEIVER_BUFFER_SIZE = 64000;
 
     private final String host;
     private final int port;


### PR DESCRIPTION
[2020-07-30 07:23:41.930] [ERROR] [SYSTEM] java.lang.OutOfMemoryError: Java heap space
        at java.base/java.nio.HeapByteBuffer.<init>(HeapByteBuffer.java:61)
        at java.base/java.nio.ByteBuffer.allocate(ByteBuffer.java:348)
        at tr.havelsan.ueransim.sctp.SctpClient.receiverLoop(SctpClient.java:87)
        at tr.havelsan.ueransim.core.threads.SctpRecevierThread.run(SctpRecevierThread.java:50)