### PR TITLE
Fix the NULL SQN exception when enabling USE_SQN_HACK:

### DIFF
--- a/ueransim/src/main/java/tr/havelsan/ueransim/api/ue/mm/MmAuthentication.java
+++ b/ueransim/src/main/java/tr/havelsan/ueransim/api/ue/mm/MmAuthentication.java
@@ -261,7 +261,7 @@ public class MmAuthentication {
 
         if (USE_SQN_HACK) {
             ctx.ueData.sqn = OctetString.xor(autn.substring(0, 6),
-                    calculateMilenage(ctx.ueConfig, ctx.ueData.sqn, rand).get(MilenageResult.AK));
+                    calculateMilenage(ctx.ueConfig, new OctetString("000000000000"), rand).get(MilenageResult.AK));
         }
 
         var milenage = calculateMilenage(ctx.ueConfig, ctx.ueData.sqn, rand);


### PR DESCRIPTION
[2020-07-30 08:03:19.162]   [FUNC_IN] Handling: 5G AKA Authentication Request
[2020-07-30 08:03:19.163]     [WARNING] [CONFIG] USE_SQN_HACK: true
[2020-07-30 08:03:19.163]     [DEBUG] [VALUE] received rand: 4e7e11a214585969e03698b67be9476d
[2020-07-30 08:03:19.164]     [DEBUG] [VALUE] received autn: dc96abd6e81a800001a542365f90a3fa
[2020-07-30 08:03:19.241]     [ERROR] [SYSTEM] java.lang.RuntimeException: java.lang.NullPointerException
        at tr.havelsan.ueransim.api.ue.mm.MmAuthentication.calculateMilenage(MmAuthentication.java:362)
        at tr.havelsan.ueransim.api.ue.mm.MmAuthentication.receiveAuthenticationRequest5gAka(MmAuthentication.java:264)
        at tr.havelsan.ueransim.api.ue.mm.MmAuthentication.receiveAuthenticationRequest(MmAuthentication.java:61)
        at tr.havelsan.ueransim.api.ue.mm.MobilityManagement.receiveMm(MobilityManagement.java:51)
        at tr.havelsan.ueransim.api.ue.UserEquipment.receiveNas(UserEquipment.java:83)
        at tr.havelsan.ueransim.api.ue.UserEquipment.cycle(UserEquipment.java:112)
        at tr.havelsan.ueransim.core.threads.NodeLooperThread.run(NodeLooperThread.java:50)
Caused by: java.lang.NullPointerException
        at tr.havelsan.ueransim.api.ue.mm.MmAuthentication.calculateMilenage(MmAuthentication.java:354)
        ... 6 more